### PR TITLE
Feature/improve performance

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -89,7 +89,10 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
   }, [context, options.enabled]);
 
   useEffect(() => {
-    context.subscribe(
+    if (!context.query.getOptions().onNodesChange) {
+      return;
+    }
+    const unsubscribe = context.subscribe(
       (_) => ({
         json: context.query.serialize(),
       }),
@@ -97,6 +100,11 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
         context.query.getOptions().onNodesChange(context.query);
       }
     );
+    return () => {
+      if (unsubscribe) {
+        return unsubscribe();
+      }
+    };
   }, [context]);
 
   return context ? (

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -18,8 +18,9 @@ export const editorInitialState: EditorState = {
     hovered: new Set<NodeId>(),
   },
   indicator: null,
+  handlers: null,
   options: {
-    onNodesChange: () => null,
+    onNodesChange: null,
     onRender: ({ render }) => render,
     onBeforeMoveEnd: () => null,
     resolver: {},


### PR DESCRIPTION
### Why?

Users were facing terrible performance issues due to the huge amount of widgets added in the page.

### What and How?

We modified the config changes subscriber `onNodesChange` in `core` package. We defined the default value to `null`, for disabling serialization on mount in (packages/core/editor/Editor.tsx). This serialization causes long task creation which stops all processes in browser and a white screen is shown for 3-6 seconds  (scripting logic from the screenshot above). This issue takes not so much time for small configurations, but with bigger ones it creates a huge lag for about (3-6 seconds). If there is no `onNodesChange` handler provided, store subscriber with serialization is not created.

### Screenshot comparing performance
#### Before:
<img width="1504" alt="before" src="https://github.com/javimorata/craft.js/assets/9108867/e790424a-eb56-47a8-8a22-3f7e146fe8d6">

#### After:
<img width="1510" alt="after" src="https://github.com/javimorata/craft.js/assets/9108867/09cae446-c49b-4cd4-95d7-b6794909cc55">
